### PR TITLE
HTTPS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It is fully free and fully open source. The license is Apache 2.0, meaning you a
 One command installation
 `bin/plugin install logstash-output-amazon_es`
 
-While we are in the process of getting this plugin fully integrated within logstash to make installation simpler, 
+While we are in the process of getting this plugin fully integrated within logstash to make installation simpler,
 if above does not work, or you would like to patch code here is a workaround to install this plugin within your logstash:
 
 1. Check out/clone this code from github
@@ -28,19 +28,19 @@ An example configuration:
 	        hosts => ["foo.us-east-1.es.amazonaws.com"]
 	        region => "us-east-1"
 			aws_access_key_id => 'ACCESS_KEY' (Will be made optional in next release to support instance profiles)
-			aws_secret_access_key => 'SECRET_KEY' 
+			aws_secret_access_key => 'SECRET_KEY'
 			index => "production-logs-%{+YYYY.MM.dd}"
 		}
 	}
-  
+
 * Required Parameters
 	* hosts (array of string) - Amazon Elasticsearch domain endpoint. eg ["foo.us-east-1.es.amazonaws.com"]
     * region (string, :default => "us-east-1") - region where the domain is located
-    
+
 * Optional Parameters
 	* Credential parameters
 		* aws_access_key_id, :validate => :string - Optional AWS Access key
-		* aws_secret_access_key, :validate => :string - Optional AWS Secret Key  
+		* aws_secret_access_key, :validate => :string - Optional AWS Secret Key
 		   The credential resolution logic can be described as follows:
 		   - User passed aws_access_key_id and aws_secret_access_key in aes configuration
 		   - Environment Variables - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
@@ -63,6 +63,7 @@ An example configuration:
 	* template (path) - You can set the path to your own template here, if you so desire. If not set, the included template will be used.
 	* template_name (string, default => "logstash") - defines how the template is named inside Elasticsearch
 	* port (string, default 80) - Amazon Elasticsearch Service listens on port 80, if you have a custom proxy fronting elasticsearch, this parameter may need tweaking.
+  * scheme (string, default `http`) - Scheme to use for Elasticsearch transport.
 
 ## Documentation
 
@@ -108,7 +109,7 @@ bundle exec rspec
 Dependencies: [Docker](http://docker.com)
 
 Before the test suite is run, we will load and run an
-Elasticsearch instance within a docker container. This container 
+Elasticsearch instance within a docker container. This container
 will be cleaned up when suite has finished.
 
 ```sh

--- a/lib/logstash/outputs/amazon_es.rb
+++ b/lib/logstash/outputs/amazon_es.rb
@@ -14,11 +14,11 @@ require "uri"
 #
 #
 # The configuration and experience is similar to logstash-output-elasticsearch plugin and we have added Signature V4 support for the same
-# Some of the default configurations like connection timeouts have been tuned for optimal performance with Amazon Elasticsearch 
+# Some of the default configurations like connection timeouts have been tuned for optimal performance with Amazon Elasticsearch
 #
 # ==== Retry Policy
 #
-# This plugin uses the same retry policy as logstash-output-elasticsearch, It uses bulk API to optimize its  
+# This plugin uses the same retry policy as logstash-output-elasticsearch, It uses bulk API to optimize its
 # imports into Elasticsearch.. These requests may experience either partial or total failures.
 # Events are retried if they fail due to either a network error or the status codes
 # 429 (the server is busy), 409 (Version Conflict), or 503 (temporary overloading/maintenance).
@@ -53,13 +53,13 @@ class LogStash::Outputs::AmazonES < LogStash::Outputs::Base
 
   # The index type to write events to. Generally you should try to write only
   # similar events to the same 'type'. String expansion `%{foo}` works here.
-  # 
+  #
   # Deprecated in favor of `document_type` field.
   config :index_type, :validate => :string, :deprecated => "Please use the 'document_type' setting instead. It has the same effect, but is more appropriately named."
 
   # The document type to write events to. Generally you should try to write only
   # similar events to the same 'type'. String expansion `%{foo}` works here.
-  # Unless you set 'document_type', the event 'type' will be used if it exists 
+  # Unless you set 'document_type', the event 'type' will be used if it exists
   # otherwise the document type will be assigned the value of 'logs'
   config :document_type, :validate => :string
 
@@ -100,28 +100,28 @@ class LogStash::Outputs::AmazonES < LogStash::Outputs::Base
   config :routing, :validate => :string
 
 
-# Set the endpoint of your Amazon Elasticsearch domain. This will always be array of size 1 
+# Set the endpoint of your Amazon Elasticsearch domain. This will always be array of size 1
 #     ["foo.us-east-1.es.amazonaws.com"]
   config :hosts, :validate => :array
 
   # You can set the remote port as part of the host, or explicitly here as well
   config :port, :validate => :string, :default => 80
-  
+
   #Signing specific details
   config :region, :validate => :string, :default => "us-east-1"
-  
-  # aws_access_key_id and aws_secret_access_key are currently needed for this plugin to work right. 
+
+  # aws_access_key_id and aws_secret_access_key are currently needed for this plugin to work right.
   # Subsequent versions will have the credential resolution logic as follows:
   #
-  # - User passed aws_access_key_id and aws_secret_access_key in aes configuration 
-  # - Environment Variables - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY 
-  #   (RECOMMENDED since they are recognized by all the AWS SDKs and CLI except for .NET), 
+  # - User passed aws_access_key_id and aws_secret_access_key in aes configuration
+  # - Environment Variables - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+  #   (RECOMMENDED since they are recognized by all the AWS SDKs and CLI except for .NET),
   #   or AWS_ACCESS_KEY and AWS_SECRET_KEY (only recognized by Java SDK)
   # - Credential profiles file at the default location (~/.aws/credentials) shared by all AWS SDKs and the AWS CLI
   # - Instance profile credentials delivered through the Amazon EC2 metadata service
   config :aws_access_key_id, :validate => :string
   config :aws_secret_access_key, :validate => :string
-  
+
 
   # This plugin uses the bulk index api for improved indexing performance.
   # To make efficient bulk api calls, we will buffer a certain number of
@@ -288,7 +288,7 @@ class LogStash::Outputs::AmazonES < LogStash::Outputs::Base
   def receive(event)
     return unless output?(event)
 
-    # block until we have not maxed out our 
+    # block until we have not maxed out our
     # retry queue. This is applying back-pressure
     # to slow down the receive-rate
     @retry_flush_mutex.synchronize {
@@ -312,7 +312,7 @@ class LogStash::Outputs::AmazonES < LogStash::Outputs::Base
       :_type => type,
       :_routing => @routing ? event.sprintf(@routing) : nil
     }
-    
+
     params[:_upsert] = LogStash::Json.load(event.sprintf(@upsert)) if @action == 'update' && @upsert != ""
 
     buffer_receive([event.sprintf(@action), params, event])
@@ -389,19 +389,19 @@ class LogStash::Outputs::AmazonES < LogStash::Outputs::Base
 
     @retry_teardown_requested.make_true
     # First, make sure retry_timer_thread is stopped
-    # to ensure we do not signal a retry based on 
+    # to ensure we do not signal a retry based on
     # the retry interval.
     Thread.kill(@retry_timer_thread)
     @retry_timer_thread.join
-    # Signal flushing in the case that #retry_flush is in 
+    # Signal flushing in the case that #retry_flush is in
     # the process of waiting for a signal.
     @retry_flush_mutex.synchronize { @retry_queue_needs_flushing.signal }
-    # Now, #retry_flush is ensured to not be in a state of 
+    # Now, #retry_flush is ensured to not be in a state of
     # waiting and can be safely joined into the main thread
     # for further final execution of an in-process remaining call.
     @retry_thread.join
 
-    # execute any final actions along with a proceeding retry for any 
+    # execute any final actions along with a proceeding retry for any
     # final actions that did not succeed.
     buffer_flush(:final => true)
     retry_flush
@@ -435,11 +435,11 @@ class LogStash::Outputs::AmazonES < LogStash::Outputs::Base
 
 
   private
-  # in charge of submitting any actions in @retry_queue that need to be 
+  # in charge of submitting any actions in @retry_queue that need to be
   # retried
   #
   # This method is not called concurrently. It is only called by @retry_thread
-  # and once that thread is ended during the teardown process, a final call 
+  # and once that thread is ended during the teardown process, a final call
   # to this method is done upon teardown in the main thread.
   def retry_flush()
     unless @retry_queue.empty?

--- a/lib/logstash/outputs/amazon_es.rb
+++ b/lib/logstash/outputs/amazon_es.rb
@@ -188,6 +188,10 @@ class LogStash::Outputs::AmazonES < LogStash::Outputs::Base
   # create a new document with this parameter as json string if document_id doesn't exists
   config :upsert, :validate => :string, :default => ""
 
+  # Enable SSL
+  # send documents to elasticsearch with https (set to true) or http (set to false)
+  config :scheme, :validate => %w(http https), :default => 'http'
+
   public
   def register
     @hosts = Array(@hosts)
@@ -224,7 +228,12 @@ class LogStash::Outputs::AmazonES < LogStash::Outputs::Base
     common_options.merge! update_options if @action == 'update'
 
     @client = LogStash::Outputs::AES::HttpClient.new(
-      common_options.merge(:hosts => @hosts, :port => @port, :region => @region, :aws_access_key_id => @aws_access_key_id, :aws_secret_access_key => @aws_secret_access_key)
+      common_options.merge(:hosts => @hosts,
+                           :port => @port,
+                           :region => @region,
+                           :aws_access_key_id => @aws_access_key_id,
+                           :aws_secret_access_key => @aws_secret_access_key,
+                           :scheme => @scheme)
     )
 
     if @manage_template

--- a/lib/logstash/outputs/amazon_es/http_client.rb
+++ b/lib/logstash/outputs/amazon_es/http_client.rb
@@ -59,6 +59,8 @@ module LogStash::Outputs::AES
     def build_client(options)
       hosts = options[:hosts]
       port = options[:port]
+      port = 443 if port.to_s == '80' && options[:scheme] == 'https'
+
       client_settings = options[:client_settings] || {}
 
       uris = hosts.map do |host|

--- a/lib/logstash/outputs/amazon_es/http_client.rb
+++ b/lib/logstash/outputs/amazon_es/http_client.rb
@@ -62,7 +62,7 @@ module LogStash::Outputs::AES
       client_settings = options[:client_settings] || {}
 
       uris = hosts.map do |host|
-        "http://#{host}:#{port}#{client_settings[:path]}".gsub(/[\/]+$/,'')
+        "#{options[:scheme]}://#{host}:#{port}#{client_settings[:path]}".gsub(/[\/]+$/,'')
       end
 
       @client_options = {
@@ -72,9 +72,10 @@ module LogStash::Outputs::AES
         :aws_secret_access_key => options[:aws_secret_access_key],
         :transport_options => {
           :request => {:open_timeout => 0, :timeout => 60},  # ELB timeouts are set at 60
-          :proxy => client_settings[:proxy],          
+          :proxy => client_settings[:proxy],
         },
-        :transport_class => Elasticsearch::Transport::Transport::HTTP::AWS
+        :transport_class => Elasticsearch::Transport::Transport::HTTP::AWS,
+        :scheme => options[:scheme]
       }
 
       if options[:user] && options[:password] then

--- a/logstash-output-amazon_es.gemspec
+++ b/logstash-output-amazon_es.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency 'concurrent-ruby'
+  s.add_runtime_dependency 'concurrent-ruby', '0.9.1'
   s.add_runtime_dependency 'elasticsearch', ['>= 1.0.10', '~> 1.0']
   s.add_runtime_dependency 'stud', ['>= 0.0.17', '~> 0.0']
   s.add_runtime_dependency 'cabin', ['~> 0.6']

--- a/spec/unit/outputs/elasticsearch/protocol_spec.rb
+++ b/spec/unit/outputs/elasticsearch/protocol_spec.rb
@@ -3,11 +3,30 @@ require "logstash/outputs/amazon_es/http_client"
 require "java"
 
 describe LogStash::Outputs::AES::HttpClient do
+  describe '@client.transport' do
+
+    describe 'scheme' do
+      let(:transport) { described_class.new(options).client.transport }
+
+      subject(:schemes) { transport.connections.connections.map { |c| c.host[:scheme] } }
+
+      context 'http' do
+        let(:options)   { { :scheme => 'http', :hosts => ['localhost'] } }
+        it { is_expected.to eq(%w(http)) }
+      end
+
+      context 'https' do
+        let(:options)   { { :scheme => 'https', :hosts => ['localhost'] } }
+        it { is_expected.to eq(%w(https)) }
+      end
+    end
+  end
+
   context "successful" do
     it "should map correctly" do
       bulk_response = {"took"=>74, "errors"=>false, "items"=>[{"create"=>{"_index"=>"logstash-2014.11.17",
                                                                           "_type"=>"logs", "_id"=>"AUxTS2C55Jrgi-hC6rQF",
-                                                                          "_version"=>1, "status"=>201}}]} 
+                                                                          "_version"=>1, "status"=>201}}]}
       actual = LogStash::Outputs::AES::HttpClient.normalize_bulk_response(bulk_response)
       insist { actual } == {"errors"=> false}
     end


### PR DESCRIPTION
Allows `scheme` to be set to `https` to send data to Elasticsearch over `https`