### PR TITLE
Upgrade to Logstash 2.2 API

### DIFF
--- a/logstash-output-amazon_es.gemspec
+++ b/logstash-output-amazon_es.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'elasticsearch', ['>= 1.0.10']
   s.add_runtime_dependency 'stud', ['>= 0.0.17', '~> 0.0']
   s.add_runtime_dependency 'cabin', ['~> 0.6']
-  s.add_runtime_dependency "logstash-core", ">= 1.4.0", "< 3.0.0"
+  s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 3.0.0"
   s.add_runtime_dependency "aws-sdk", ['>= 2.1.14', '~> 2']
   s.add_runtime_dependency "faraday", '~> 0.9.1'
   s.add_runtime_dependency "faraday_middleware", '~> 0.10.0'


### PR DESCRIPTION
This makes sure the output shuts down properly with Logstash 2.2+. It also removes the unnecessary `output?` method call.

The minimum required `logstash-core` version is now `2.0.0` to keep in line with other plugins. However, it is possible to retain backwards compatibility.
