### PR TITLE
Docker-ize plugin build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Source: https://github.com/cpuguy83/docker-jruby/blob/1f289ddb5d77c41b9f096384bdc412efa76e3d63/1.7/jre/Dockerfile
+
+FROM java:8-jre
+
+RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV JRUBY_VERSION 1.7.22
+ENV JRUBY_SHA1 6b9e310a04ad8173d0d6dbe299da04c0ef85fc15
+RUN mkdir /opt/jruby \
+  && curl -fSL https://s3.amazonaws.com/jruby.org/downloads/${JRUBY_VERSION}/jruby-bin-${JRUBY_VERSION}.tar.gz -o /tmp/jruby.tar.gz \
+  && echo "$JRUBY_SHA1 /tmp/jruby.tar.gz" | sha1sum -c - \
+  && tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
+  && rm /tmp/jruby.tar.gz \
+  && update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1
+ENV PATH /opt/jruby/bin:$PATH
+
+RUN echo 'gem: --no-rdoc --no-ri' >> ~/.gemrc
+
+ENV GEM_HOME /usr/local/bundle
+ENV PATH $GEM_HOME/bin:$PATH
+RUN gem install bundler \
+	&& bundle config --global path "$GEM_HOME" \
+	&& bundle config --global bin "$GEM_HOME/bin"
+
+# don't create ".bundle" in all our apps
+ENV BUNDLE_APP_CONFIG $GEM_HOME
+
+RUN mkdir /var/build_dir
+
+# The contents of the volume are the actual build sources as defined in docker-compose.yml ('-v .:/var/build').
+VOLUME /var/build_dir 
+
+WORKDIR /var/build_dir
+
+# The build tool.
+ENTRYPOINT ["gem"]
+
+# Setting default args for entrypoint command.
+# Running the container should result in a binary inside the host-mounted volume named 'logstash-output-amazon_es-<VERSION>-java.gem'.
+# Where <VERSION> is defined as value of 's.version' in logstash-output-amazon_es.gemspec file.
+CMD [ "build", "logstash-output-amazon_es.gemspec" ]

--- a/README.md
+++ b/README.md
@@ -158,3 +158,14 @@ Programming is not a required skill. Whatever you've seen about open source and 
 It is more important to the community that you are able to contribute.
 
 For more information about contributing, see the [CONTRIBUTING](https://github.com/elastic/logstash/blob/master/CONTRIBUTING.md) file.
+
+## Building the Logstash output plugin with Docker
+
+**Prerequisites:**
+
+- [Docker Engine](https://www.docker.com/products/docker-engine) >= 1.9.1
+- [Docker Compose](https://docs.docker.com/compose/) >= 1.6.0
+
+		docker-compose up
+
+This will result in a newly created binary inside the host-mounted volume `${PWD}` named `logstash-output-amazon_es-<VERSION>-java.gem`. Where `<VERSION>` is defined as value of `s.version` in [logstash-output-amazon_es.gemspec](logstash-output-amazon_es.gemspec) file.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+
+# Running 'docker-compose up' should build the logstash-output-amazon_es Logstash plugin.
+# This will result in a newly created binary inside the host-mounted volume ${PWD} named 'logstash-output-amazon_es-<VERSION>-java.gem'.
+# Where <VERSION> is defined as value of 's.version' in logstash-output-amazon_es.gemspec file.
+
+version: '2'
+services:
+  jruby:
+    build: .
+    volumes:
+     - .:/var/build_dir
+  


### PR DESCRIPTION
Allows building the output plugin by simply executing `docker-compose up`.