### PR TITLE
Add support for SESSION_TOKEN

### DIFF
--- a/lib/logstash/outputs/amazon_es.rb
+++ b/lib/logstash/outputs/amazon_es.rb
@@ -115,7 +115,7 @@ class LogStash::Outputs::AmazonES < LogStash::Outputs::Base
 
   # Credential resolution logic works as follows:
   #
-  # - User passed aws_access_key_id and aws_secret_access_key in aes configuration
+  # - User passed aws_access_key_id and aws_secret_access_key and session_token in aes configuration
   # - Environment Variables - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
   #   (RECOMMENDED since they are recognized by all the AWS SDKs and CLI except for .NET),
   #   or AWS_ACCESS_KEY and AWS_SECRET_KEY (only recognized by Java SDK)
@@ -123,7 +123,7 @@ class LogStash::Outputs::AmazonES < LogStash::Outputs::Base
   # - Instance profile credentials delivered through the Amazon EC2 metadata service
   config :aws_access_key_id, :validate => :string
   config :aws_secret_access_key, :validate => :string
-
+  config :aws_session_token, :validate => :string
 
   # This plugin uses the bulk index api for improved indexing performance.
   # To make efficient bulk api calls, we will buffer a certain number of
@@ -226,7 +226,7 @@ class LogStash::Outputs::AmazonES < LogStash::Outputs::Base
     common_options.merge! update_options if @action == 'update'
 
     @client = LogStash::Outputs::AES::HttpClient.new(
-      common_options.merge(:hosts => @hosts, :port => @port, :region => @region, :aws_access_key_id => @aws_access_key_id, :aws_secret_access_key => @aws_secret_access_key,:protocol => @protocol)
+      common_options.merge(:hosts => @hosts, :port => @port, :region => @region, :aws_access_key_id => @aws_access_key_id, :aws_secret_access_key => @aws_secret_access_key, :aws_session_token => @aws_session_token, :protocol => @protocol)
     )
 
     if @manage_template

--- a/lib/logstash/outputs/amazon_es/aws_transport.rb
+++ b/lib/logstash/outputs/amazon_es/aws_transport.rb
@@ -24,17 +24,17 @@ module Elasticsearch
         #
         class AWS
           include Elasticsearch::Transport::Transport::Base
-          
+
 
           DEFAULT_PORT = 80
-          DEFAULT_PROTOCOL = "http"    
-          
+          DEFAULT_PROTOCOL = "http"
+
           CredentialConfig = Struct.new(
             :access_key_id,
             :secret_access_key,
             :session_token,
             :profile
-          )      
+          )
 
           # Performs the request by invoking {Transport::Base#perform_request} with a block.
           #
@@ -61,9 +61,9 @@ module Elasticsearch
             region = options[:region]
             access_key_id = options[:aws_access_key_id] || nil
             secret_access_key = options[:aws_secret_access_key] || nil
-            session_token = options[:session_token] || nil
+            session_token = options[:aws_session_token] || nil
             profile = options[:profile] || 'default'
-            
+
             credential_config = CredentialConfig.new(access_key_id, secret_access_key, session_token, profile)
             credentials = Aws::CredentialProviderChain.new(credential_config).resolve
 
@@ -72,7 +72,7 @@ module Elasticsearch
                 host[:protocol]   = host[:scheme] || DEFAULT_PROTOCOL
                 host[:port]     ||= DEFAULT_PORT
                 url               = __full_url(host)
-                                  
+
                 aes_connection = ::Faraday::Connection.new(url,  (options[:transport_options] || {})) do |faraday|
                   faraday.request :aws_v4_signer,
                                         credentials: credentials,
@@ -80,7 +80,7 @@ module Elasticsearch
                                         region: region
                   faraday.adapter :manticore
                 end
-                
+
                 Connections::Connection.new \
                   :host => host,
                   :connection => aes_connection

--- a/lib/logstash/outputs/amazon_es/http_client.rb
+++ b/lib/logstash/outputs/amazon_es/http_client.rb
@@ -71,6 +71,7 @@ module LogStash::Outputs::AES
         :region => options[:region],
         :aws_access_key_id => options[:aws_access_key_id],
         :aws_secret_access_key => options[:aws_secret_access_key],
+        :aws_session_token => options[:aws_session_token],
         :transport_options => {
           :request => {:open_timeout => 0, :timeout => 60},  # ELB timeouts are set at 60
           :proxy => client_settings[:proxy],


### PR DESCRIPTION
This allows the plugin to use the SESSION_TOKEN so that it can run as an IAM role. 