### PR TITLE
Bump the `elasticsearch` gem

### DIFF
--- a/logstash-output-amazon_es.gemspec
+++ b/logstash-output-amazon_es.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-amazon_es'
-  s.version         = '1.1.0'
+  s.version         = '2.0.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Amazon Elasticsearch Service"
   s.description     = "Output events to Amazon Elasticsearch Service with V4 signing"
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency 'concurrent-ruby'
-  s.add_runtime_dependency 'elasticsearch', '~> 1.0', '>= 1.0.10'
+  s.add_runtime_dependency 'elasticsearch', '>= 1.0.10', '< 6.0.0'
   s.add_runtime_dependency 'stud', ['>= 0.0.17', '~> 0.0']
   s.add_runtime_dependency 'cabin', ['~> 0.6']
   s.add_runtime_dependency 'logstash-core-plugin-api', '>= 1.60', '<= 2.99'


### PR DESCRIPTION
Bump the `elasticsearch` gem to the latest version. Currently the `logstash-output-amazon_es` plugin cannot be installed on the latest version of Logstash (version 5.2.1) because the dependencies conflict with those of `logstash-input-elasticsearch` (which is bundled with Logstash itself). Specifically, I am getting the following error message:

```
> /usr/share/logstash/bin/logstash-plugin install logstash-output-amazon_es
Validating logstash-output-amazon_es
Installing logstash-output-amazon_es
Plugin version conflict, aborting
ERROR: Installation Aborted, message: Bundler could not find compatible versions for gem "elasticsearch":
  In snapshot (Gemfile.lock):
    elasticsearch (= 5.0.3)

  In Gemfile:
    logstash-input-elasticsearch (>= 0) java depends on
      elasticsearch (< 6.0.0, >= 5.0.3) java

    logstash-output-amazon_es (>= 0) java depends on
      elasticsearch (>= 1.0.10, ~> 1.0) java

    elasticsearch (>= 0) java

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
Bundler could not find compatible versions for gem "logstash-core":
  In snapshot (Gemfile.lock):
    logstash-core (= 5.2.1)

  In Gemfile:
    logstash-core-plugin-api (>= 0) java depends on
      logstash-core (= 5.2.1) java

    logstash-output-amazon_es (>= 0) java depends on
      logstash-core (< 2.0.0, >= 1.4.0) java

    logstash-core (>= 0) java

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

To fix this, we can simply update the `elasticsearch` gem to the latest version.