### PR TITLE
add document_type property to configuration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ An example configuration:
 		* max_retries (number, default => 3) - Set max retry for each event
 		* retry_max_items (number, default => 5000) - Set retry queue size for events that failed to send
 		* retry_max_interval (number, default => 5) - Set max interval between bulk retries
-	* document_type (string - all lowercase, default => "logs") - set the type of documents going to Elasticsearch.  Note that in ES 6.x, indexes are [limited to a single document type](http://nocf-www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html#_schedule_for_removal_of_mapping_types).  
-	Also note that if you're using [an index template from beats](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-template.html#load-template-shell) with this plugins, beats defaults to generating documents of type "doc", so make sure to set this value to "doc" if using in conjunction with beats.  
+	* document_type (string - all lowercase, default => "logs") - set the type of documents going to Elasticsearch.  Note that in ES 6.x, indexes are [limited to a single document type](http://nocf-www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html#_schedule_for_removal_of_mapping_types).  Also note that if you're using [an index template from beats](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-template.html#load-template-shell) with this plugin, beats defaults to generating documents of type "doc", so make sure to set this value to "doc" if using in conjunction with beats.  
 	* index (string - all lowercase, default => "logstash-%{+YYYY.MM.dd}") - Elasticsearch index to write events into
 	* flush_size (number , default => 500) - This setting controls how many events will be buffered before sending a batch of events in bulk API
 	* idle_flush_time (number, default => 1) - The amount of time in seconds since last flush before a flush is forced.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ An example configuration:
 		* max_retries (number, default => 3) - Set max retry for each event
 		* retry_max_items (number, default => 5000) - Set retry queue size for events that failed to send
 		* retry_max_interval (number, default => 5) - Set max interval between bulk retries
+	* document_type (string - all lowercase, default => "logs") - set the type of documents going to Elasticsearch.  Note that in ES 6.x, indexes are [limited to a single document type](http://nocf-www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html#_schedule_for_removal_of_mapping_types).  
+	Also note that if you're using [an index template from beats](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-template.html#load-template-shell) with this plugins, beats defaults to generating documents of type "doc", so make sure to set this value to "doc" if using in conjunction with beats.  
 	* index (string - all lowercase, default => "logstash-%{+YYYY.MM.dd}") - Elasticsearch index to write events into
 	* flush_size (number , default => 500) - This setting controls how many events will be buffered before sending a batch of events in bulk API
 	* idle_flush_time (number, default => 1) - The amount of time in seconds since last flush before a flush is forced.


### PR DESCRIPTION
I banged my head against a filebeat problem for like two days, until I realized the index template filebeat creates is not compatible with the default options of logstash-output-amazon_es.  I've added the section for "document_type" (you can find the config property here https://github.com/awslabs/logstash-output-amazon_es/blob/a34c29a82707d3a559fe3ba131df2a37328ad071/lib/logstash/outputs/amazon_es.rb#L64) with a little tip so no one has to lose another day to googling "my AWS elasticsearch cluster stopped accepting documents" :)