### PR TITLE
Update elasticsearch-template.json for Elasticsearch 6.x

### DIFF
--- a/lib/logstash/outputs/amazon_es/elasticsearch-template.json
+++ b/lib/logstash/outputs/amazon_es/elasticsearch-template.json
@@ -1,41 +1,45 @@
 {
   "template" : "logstash-*",
+  "version" : 60001,
   "settings" : {
     "index.refresh_interval" : "5s"
   },
   "mappings" : {
     "_default_" : {
-       "_all" : {"enabled" : true, "omit_norms" : true},
-       "dynamic_templates" : [ {
-         "message_field" : {
-           "match" : "message",
-           "match_mapping_type" : "string",
-           "mapping" : {
-             "type" : "string", "index" : "analyzed", "omit_norms" : true
-           }
-         }
-       }, {
-         "string_fields" : {
-           "match" : "*",
-           "match_mapping_type" : "string",
-           "mapping" : {
-             "type" : "string", "index" : "analyzed", "omit_norms" : true,
-               "fields" : {
-                 "raw" : {"type": "string", "index" : "not_analyzed", "ignore_above" : 256}
-               }
-           }
-         }
-       } ],
-       "properties" : {
-         "@version": { "type": "string", "index": "not_analyzed" },
-         "geoip"  : {
-           "type" : "object",
-             "dynamic": true,
-             "properties" : {
-               "location" : { "type" : "geo_point" }
-             }
-         }
-       }
+      "dynamic_templates" : [ {
+        "message_field" : {
+          "path_match" : "message",
+          "match_mapping_type" : "string",
+          "mapping" : {
+            "type" : "text",
+            "norms" : false
+          }
+        }
+      }, {
+        "string_fields" : {
+          "match" : "*",
+          "match_mapping_type" : "string",
+          "mapping" : {
+            "type" : "text", "norms" : false,
+            "fields" : {
+              "keyword" : { "type": "keyword", "ignore_above": 256 }
+            }
+          }
+        }
+      } ],
+      "properties" : {
+        "@timestamp": { "type": "date"},
+        "@version": { "type": "keyword"},
+        "geoip"  : {
+          "dynamic": true,
+          "properties" : {
+            "ip": { "type": "ip" },
+            "location" : { "type" : "geo_point" },
+            "latitude" : { "type" : "half_float" },
+            "longitude" : { "type" : "half_float" }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #81.

The current mapping template is not compatible with Elasticsearch 6.x, because `@version` uses type 'string', but this is deprecated.

This PR updates to the official mapping template from https://raw.githubusercontent.com/logstash-plugins/logstash-output-elasticsearch/master/lib/logstash/outputs/elasticsearch/elasticsearch-template-es6x.json