### PR TITLE
Update logstash-output-amazon_es.gemspec

### DIFF
--- a/logstash-output-amazon_es.gemspec
+++ b/logstash-output-amazon_es.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency 'concurrent-ruby'
-  s.add_runtime_dependency 'elasticsearch', '>= 1.0.10', '< 6.0.0'
+  s.add_runtime_dependency 'elasticsearch', '>= 1.0.10', '<= 6.2.0'
   s.add_runtime_dependency 'stud', ['>= 0.0.17', '~> 0.0']
   s.add_runtime_dependency 'cabin', ['~> 0.6']
   s.add_runtime_dependency 'logstash-core-plugin-api', '>= 1.60', '<= 2.99'


### PR DESCRIPTION
Update to support latest available AWS ES version.