### PR TITLE
Update es7 template to remove types

### DIFF
--- a/lib/logstash/outputs/amazon_es/elasticsearch-template-es7x.json
+++ b/lib/logstash/outputs/amazon_es/elasticsearch-template-es7x.json
@@ -1,6 +1,6 @@
 {
   "template" : "logstash-*",
-  "version" : 60001,
+  "version" : 60002,
   "settings" : {
     "index.refresh_interval" : "5s",
     "number_of_shards": 1


### PR DESCRIPTION
*Issue #128 :*

*Description of changes: Updated the template (elasticsearch-template-es7x.json) to remove types.* 

From elasticsearch-7.0, types have been removed and request parameter `include_type_name` which omits types is defaulted to `false`. This will fail while installing the template with types as reported in #128 . The current change is to remove types from the `elasticsearch-template-es7x.json` template.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
