### PR TITLE
Fixing naming and dependency conflicts with ES plugin

### DIFF
--- a/lib/logstash/outputs/amazon_es.rb
+++ b/lib/logstash/outputs/amazon_es.rb
@@ -83,7 +83,7 @@ require "forwardable"
 # For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression` 
 # setting in their Logstash config file.
 #
-class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
+class LogStash::Outputs::AmazonElasticSearch < LogStash::Outputs::Base
   declare_threadsafe!
 
   require "logstash/outputs/amazon_es/http_client"
@@ -92,10 +92,10 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   require "logstash/outputs/amazon_es/common"
 
   # Protocol agnostic (i.e. non-http, non-java specific) configs go here
-  include(LogStash::Outputs::ElasticSearch::CommonConfigs)
+  include(LogStash::Outputs::AmazonElasticSearch::CommonConfigs)
 
   # Protocol agnostic methods
-  include(LogStash::Outputs::ElasticSearch::Common)
+  include(LogStash::Outputs::AmazonElasticSearch::Common)
 
   config_name "amazon_es"
 
@@ -250,7 +250,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
   def build_client
     params["metric"] = metric
-    @client ||= ::LogStash::Outputs::ElasticSearch::HttpClientBuilder.build(@logger, @hosts, params)
+    @client ||= ::LogStash::Outputs::AmazonElasticSearch::HttpClientBuilder.build(@logger, @hosts, params)
   end
 
   def close

--- a/lib/logstash/outputs/amazon_es/common.rb
+++ b/lib/logstash/outputs/amazon_es/common.rb
@@ -1,6 +1,6 @@
 require "logstash/outputs/amazon_es/template_manager"
 
-module LogStash; module Outputs; class ElasticSearch;
+module LogStash; module Outputs; class AmazonElasticSearch;
   module Common
     attr_reader :client, :hosts
 
@@ -274,7 +274,7 @@ module LogStash; module Outputs; class ElasticSearch;
         es_actions = actions.map {|action_type, params, event| [action_type, params, event.to_hash]}
         response = @client.bulk(es_actions)
         response
-      rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError => e
+      rescue ::LogStash::Outputs::AmazonElasticSearch::HttpClient::Pool::HostUnreachableError => e
         # If we can't even connect to the server let's just print out the URL (:hosts is actually a URL)
         # and let the user sort it out from there
         @logger.error(
@@ -290,7 +290,7 @@ module LogStash; module Outputs; class ElasticSearch;
         sleep_interval = sleep_for_interval(sleep_interval)
         @bulk_request_metrics.increment(:failures)
         retry unless @stopping.true?
-      rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::NoConnectionAvailableError => e
+      rescue ::LogStash::Outputs::AmazonElasticSearch::HttpClient::Pool::NoConnectionAvailableError => e
         @logger.error(
           "Attempted to send a bulk request to elasticsearch, but no there are no living connections in the connection pool. Perhaps Elasticsearch is unreachable or down?",
           :error_message => e.message,
@@ -301,7 +301,7 @@ module LogStash; module Outputs; class ElasticSearch;
         sleep_interval = next_sleep_interval(sleep_interval)
         @bulk_request_metrics.increment(:failures)
         retry unless @stopping.true?
-      rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError => e
+      rescue ::LogStash::Outputs::AmazonElasticSearch::HttpClient::Pool::BadResponseCodeError => e
         @bulk_request_metrics.increment(:failures)
         log_hash = {:code => e.response_code, :url => e.url.sanitized.to_s}
         log_hash[:body] = e.response_body if @logger.debug? # Generally this is too verbose

--- a/lib/logstash/outputs/amazon_es/common_configs.rb
+++ b/lib/logstash/outputs/amazon_es/common_configs.rb
@@ -1,6 +1,6 @@
 require 'forwardable' # Needed for logstash core SafeURI. We need to patch this in core: https://github.com/elastic/logstash/pull/5978
 
-module LogStash; module Outputs; class ElasticSearch
+module LogStash; module Outputs; class AmazonElasticSearch
   module CommonConfigs
     def self.included(mod)
       # The index to write events to. This can be dynamic using the `%{foo}` syntax.

--- a/lib/logstash/outputs/amazon_es/http_client.rb
+++ b/lib/logstash/outputs/amazon_es/http_client.rb
@@ -7,7 +7,7 @@ require 'cgi'
 require 'zlib'
 require 'stringio'
 
-module LogStash; module Outputs; class ElasticSearch;
+module LogStash; module Outputs; class AmazonElasticSearch;
   # This is a constant instead of a config option because
   # there really isn't a good reason to configure it.
   #
@@ -152,7 +152,7 @@ module LogStash; module Outputs; class ElasticSearch;
 
       if response.code != 200
         url = ::LogStash::Util::SafeURI.new(response.final_url)
-        raise ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError.new(
+        raise ::LogStash::Outputs::AmazonElasticSearch::HttpClient::Pool::BadResponseCodeError.new(
           response.code, url, body_stream.to_s, response.body
         )
       end
@@ -292,7 +292,7 @@ module LogStash; module Outputs; class ElasticSearch;
 
       adapter_options[:aws_secret_access_key] = options[:aws_secret_access_key]
 
-      adapter_class = ::LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter
+      adapter_class = ::LogStash::Outputs::AmazonElasticSearch::HttpClient::ManticoreAdapter
       adapter = adapter_class.new(@logger, adapter_options)
     end
     
@@ -310,7 +310,7 @@ module LogStash; module Outputs; class ElasticSearch;
       }
       pool_options[:scheme] = self.scheme if self.scheme
 
-      pool_class = ::LogStash::Outputs::ElasticSearch::HttpClient::Pool
+      pool_class = ::LogStash::Outputs::AmazonElasticSearch::HttpClient::Pool
       full_urls = @options[:hosts].map {|h| host_to_url(h) }
       pool = pool_class.new(@logger, adapter, full_urls, pool_options)
       pool.start

--- a/lib/logstash/outputs/amazon_es/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/amazon_es/http_client/manticore_adapter.rb
@@ -3,7 +3,7 @@ require 'cgi'
 require 'aws-sdk-core'
 require 'uri'
 
-module LogStash; module Outputs; class ElasticSearch; class HttpClient;
+module LogStash; module Outputs; class AmazonElasticSearch; class HttpClient;
   DEFAULT_HEADERS = { "content-type" => "application/json" }
 
   CredentialConfig = Struct.new(
@@ -123,7 +123,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       # template installation. We might need a better story around this later
       # but for our current purposes this is correct
       if resp.code < 200 || resp.code > 299 && resp.code != 404
-        raise ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError.new(resp.code, request_uri, body, resp.body)
+        raise ::LogStash::Outputs::AmazonElasticSearch::HttpClient::Pool::BadResponseCodeError.new(resp.code, request_uri, body, resp.body)
       end
 
       resp

--- a/lib/logstash/outputs/amazon_es/http_client/pool.rb
+++ b/lib/logstash/outputs/amazon_es/http_client/pool.rb
@@ -1,4 +1,4 @@
-module LogStash; module Outputs; class ElasticSearch; class HttpClient;
+module LogStash; module Outputs; class AmazonElasticSearch; class HttpClient;
   class Pool
     class NoConnectionAvailableError < Error; end
     class BadResponseCodeError < Error

--- a/lib/logstash/outputs/amazon_es/http_client_builder.rb
+++ b/lib/logstash/outputs/amazon_es/http_client_builder.rb
@@ -1,6 +1,6 @@
 require 'cgi'
 
-module LogStash; module Outputs; class ElasticSearch;
+module LogStash; module Outputs; class AmazonElasticSearch;
   module HttpClientBuilder
     def self.build(logger, hosts, params)
       client_settings = {
@@ -105,7 +105,7 @@ module LogStash; module Outputs; class ElasticSearch;
     end
 
     def self.create_http_client(options)
-      LogStash::Outputs::ElasticSearch::HttpClient.new(options)
+      LogStash::Outputs::AmazonElasticSearch::HttpClient.new(options)
     end
 
     def self.setup_ssl(logger, params)

--- a/lib/logstash/outputs/amazon_es/template_manager.rb
+++ b/lib/logstash/outputs/amazon_es/template_manager.rb
@@ -1,4 +1,4 @@
-module LogStash; module Outputs; class ElasticSearch
+module LogStash; module Outputs; class AmazonElasticSearch
   class TemplateManager
     # To be mixed into the amazon_es plugin base
     def self.install_template(plugin)

--- a/logstash-output-amazon_es.gemspec
+++ b/logstash-output-amazon_es.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-amazon_es'
-  s.version         = '7.0'
+  s.version         = '7.0.1'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Logstash Output to Amazon Elasticsearch Service"
   s.description     = "Output events to Amazon Elasticsearch Service with V4 signing"
@@ -29,5 +29,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logstash-codec-plain'
   s.add_development_dependency 'logstash-devutils', "~> 1.3", ">= 1.3.1"
   s.add_development_dependency 'flores', '~> 0'
-  # Still used in some specs, we should remove this ASAP
 end

--- a/logstash-output-amazon_es.gemspec
+++ b/logstash-output-amazon_es.gemspec
@@ -26,9 +26,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'aws-sdk', '>= 2.3.22', '~> 2'
 
-  s.add_development_dependency 'logstash-codec-plain', '~> 0'
-  s.add_development_dependency 'logstash-devutils', '~> 0'
+  s.add_development_dependency 'logstash-codec-plain'
+  s.add_development_dependency 'logstash-devutils', "~> 1.3", ">= 1.3.1"
   s.add_development_dependency 'flores', '~> 0'
   # Still used in some specs, we should remove this ASAP
-  s.add_development_dependency 'elasticsearch', '~> 0'
 end

--- a/spec/es_spec_helper.rb
+++ b/spec/es_spec_helper.rb
@@ -1,6 +1,5 @@
 require "logstash/devutils/rspec/spec_helper"
 require 'manticore'
-require 'elasticsearch'
 
 # by default exclude secure_integration tests unless requested
 # normal integration specs are already excluded by devutils' spec helper
@@ -11,10 +10,6 @@ end
 module ESHelper
   def get_host_port
     "127.0.0.1"
-  end
-
-  def get_client
-    Elasticsearch::Client.new(:hosts => [get_host_port])
   end
 
   def self.es_version

--- a/spec/unit/http_client_builder_spec.rb
+++ b/spec/unit/http_client_builder_spec.rb
@@ -3,9 +3,9 @@ require "logstash/outputs/amazon_es"
 require "logstash/outputs/amazon_es/http_client"
 require "logstash/outputs/amazon_es/http_client_builder"
 
-describe LogStash::Outputs::ElasticSearch::HttpClientBuilder do
+describe LogStash::Outputs::AmazonElasticSearch::HttpClientBuilder do
   describe "auth setup with url encodable passwords" do
-    let(:klass) { LogStash::Outputs::ElasticSearch::HttpClientBuilder }
+    let(:klass) { LogStash::Outputs::AmazonElasticSearch::HttpClientBuilder }
     let(:user) { "foo@bar"}
     let(:password) {"baz@blah" }
     let(:password_secured) do

--- a/spec/unit/outputs/elasticsearch/http_client/manticore_adapter_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/manticore_adapter_spec.rb
@@ -1,7 +1,7 @@
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/outputs/amazon_es/http_client"
 
-describe LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter do
+describe LogStash::Outputs::AmazonElasticSearch::HttpClient::ManticoreAdapter do
   let(:logger) { Cabin::Channel.get }
   let(:options) { {:aws_access_key_id => 'AAAAAAAAAAAAAAAAAAAA',
                    :aws_secret_access_key => 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'} }
@@ -34,12 +34,12 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter do
       uri_with_path = uri.clone
       uri_with_path.path = "/"
 
-      expect(::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError).to receive(:new).
+      expect(::LogStash::Outputs::AmazonElasticSearch::HttpClient::Pool::BadResponseCodeError).to receive(:new).
         with(resp.code, uri_with_path, nil, resp.body).and_call_original
 
       expect do
         subject.perform_request(uri, :get, "/")
-      end.to raise_error(::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError)
+      end.to raise_error(::LogStash::Outputs::AmazonElasticSearch::HttpClient::Pool::BadResponseCodeError)
     end
   end
 

--- a/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
@@ -2,9 +2,9 @@ require "logstash/devutils/rspec/spec_helper"
 require "logstash/outputs/amazon_es/http_client"
 require "json"
 
-describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
+describe LogStash::Outputs::AmazonElasticSearch::HttpClient::Pool do
   let(:logger) { Cabin::Channel.get }
-  let(:adapter) { LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter.new(logger,
+  let(:adapter) { LogStash::Outputs::AmazonElasticSearch::HttpClient::ManticoreAdapter.new(logger,
                                                                                      {:aws_access_key_id => 'AAAAAAAAAAAAAAAAAAAA',
                                                                                               :aws_secret_access_key => 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'}) }
   let(:initial_urls) { [::LogStash::Util::SafeURI.new("http://localhost:9200")] }

--- a/spec/unit/outputs/elasticsearch/http_client_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client_spec.rb
@@ -2,7 +2,7 @@ require "logstash/devutils/rspec/spec_helper"
 require "logstash/outputs/amazon_es/http_client"
 require "java"
 
-describe LogStash::Outputs::ElasticSearch::HttpClient do
+describe LogStash::Outputs::AmazonElasticSearch::HttpClient do
   let(:ssl) { nil }
   let(:base_options) do
     opts = {
@@ -163,7 +163,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
     ]}
 
     context "if a message is over TARGET_BULK_BYTES" do
-      let(:target_bulk_bytes) { LogStash::Outputs::ElasticSearch::TARGET_BULK_BYTES }
+      let(:target_bulk_bytes) { LogStash::Outputs::AmazonElasticSearch::TARGET_BULK_BYTES }
       let(:message) { "a" * (target_bulk_bytes + 1) }
 
       it "should be handled properly" do
@@ -189,7 +189,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
       end
 
       context "if one exceeds TARGET_BULK_BYTES" do
-        let(:target_bulk_bytes) { LogStash::Outputs::ElasticSearch::TARGET_BULK_BYTES }
+        let(:target_bulk_bytes) { LogStash::Outputs::AmazonElasticSearch::TARGET_BULK_BYTES }
         let(:message1) { "a" * (target_bulk_bytes + 1) }
         it "executes two bulk_send operations" do
           allow(subject).to receive(:join_bulk_responses)
@@ -201,7 +201,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
   end
 
   describe "sniffing" do
-    let(:client) { LogStash::Outputs::ElasticSearch::HttpClient.new(base_options.merge(client_opts)) }
+    let(:client) { LogStash::Outputs::AmazonElasticSearch::HttpClient.new(base_options.merge(client_opts)) }
 
     context "with sniffing enabled" do
       let(:client_opts) { {:sniffing => true, :sniffing_delay => 1 } }

--- a/spec/unit/outputs/elasticsearch/template_manager_spec.rb
+++ b/spec/unit/outputs/elasticsearch/template_manager_spec.rb
@@ -3,7 +3,7 @@ require "logstash/outputs/amazon_es/http_client"
 require "java"
 require "json"
 
-describe LogStash::Outputs::ElasticSearch::TemplateManager do
+describe LogStash::Outputs::AmazonElasticSearch::TemplateManager do
 
   describe ".default_template_path" do
     context "amazon_es 1.x" do

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -2,7 +2,7 @@ require_relative "../../../spec/es_spec_helper"
 require "flores/random"
 require "logstash/outputs/amazon_es"
 
-describe LogStash::Outputs::ElasticSearch do
+describe LogStash::Outputs::AmazonElasticSearch do
   subject { described_class.new(options) }
   let(:options) { { "aws_access_key_id" => "AAAAAAAAAAAAAAAAAAAA",
                     "aws_secret_access_key" => "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"} }
@@ -222,7 +222,7 @@ describe LogStash::Outputs::ElasticSearch do
     context "429 errors" do
       let(:event) { ::LogStash::Event.new("foo" => "bar") }
       let(:error) do
-        ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError.new(
+        ::LogStash::Outputs::AmazonElasticSearch::HttpClient::Pool::BadResponseCodeError.new(
           429, double("url").as_null_object, double("request body"), double("response body")
         )
       end

--- a/spec/unit/outputs/error_whitelist_spec.rb
+++ b/spec/unit/outputs/error_whitelist_spec.rb
@@ -14,7 +14,7 @@ describe "whitelisting error types in expected behavior" do
                     "aws_access_key_id" => "AAAAAAAAAAAAAAAAAAAA",
                     "aws_secret_access_key" => "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"} }
 
-  subject { LogStash::Outputs::ElasticSearch.new(settings) }
+  subject { LogStash::Outputs::AmazonElasticSearch.new(settings) }
 
   before :each do
     allow(subject.logger).to receive(:warn)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/logstash-output-amazon_es/issues/114

*Description of changes:*
Rename namespace of the plugin from ElasticSearch to AmazonElasticSearch. Remove ElasticSearch plugin dependency. Update logstash-devutils dependency to avoid rspec errors.

Tested manually by running both an AmazonElasticSearch and regular ElasticSearch output plugin on the same logstash pipeline and verifying data is posted to both clusters without errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
