### PR TITLE
Max bulk size parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ output {
 - template_name (string, default => "logstash") - defines how the template is named inside Elasticsearch
 - port (string, default 443) - Amazon Elasticsearch Service listens on port 443 for HTTPS (default) and port 80 for HTTP. Tweak this value for a custom proxy.
 - protocol (string, default https) - The protocol used to connect to the Amazon Elasticsearch Service
+- max_bulk_bytes - The max size for a bulk request in bytes. Default is 20MB. It is recommended not to change this value unless needed. For guidance on changing this value, please consult the table for network limits for your instance type: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-limits.html
 
 After 6.4.0, users can't set batch size in this output plugin config. However, users can still set batch size in logstash.yml file.
 ## Developing

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ output {
 - template_name (string, default => "logstash") - defines how the template is named inside Elasticsearch
 - port (string, default 443) - Amazon Elasticsearch Service listens on port 443 for HTTPS (default) and port 80 for HTTP. Tweak this value for a custom proxy.
 - protocol (string, default https) - The protocol used to connect to the Amazon Elasticsearch Service
-- max_bulk_bytes - The max size for a bulk request in bytes. Default is 20MB. It is recommended not to change this value unless needed. For guidance on changing this value, please consult the table for network limits for your instance type: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-limits.html
+- max_bulk_bytes - The max size for a bulk request in bytes. Default is 20MB. It is recommended not to change this value unless needed. For guidance on changing this value, please consult the table for network limits for your instance type: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-limits.html#network-limits
 
 After 6.4.0, users can't set batch size in this output plugin config. However, users can still set batch size in logstash.yml file.
 ## Developing

--- a/lib/logstash/outputs/amazon_es.rb
+++ b/lib/logstash/outputs/amazon_es.rb
@@ -248,7 +248,7 @@ class LogStash::Outputs::AmazonElasticSearch < LogStash::Outputs::Base
   # Custom Headers to send on each request to amazon_es nodes
   config :custom_headers, :validate => :hash, :default => {}
 
-  #Max builk size in bytes
+  #Max bulk size in bytes
   config :max_bulk_bytes, :validate => :number, :default => 20 * 1024 * 1024
 
   def build_client

--- a/lib/logstash/outputs/amazon_es.rb
+++ b/lib/logstash/outputs/amazon_es.rb
@@ -248,6 +248,9 @@ class LogStash::Outputs::AmazonElasticSearch < LogStash::Outputs::Base
   # Custom Headers to send on each request to amazon_es nodes
   config :custom_headers, :validate => :hash, :default => {}
 
+  #Max builk size in bytes
+  config :max_bulk_bytes, :validate => :number, :default => 20 * 1024 * 1024
+
   def build_client
     params["metric"] = metric
     @client ||= ::LogStash::Outputs::AmazonElasticSearch::HttpClientBuilder.build(@logger, @hosts, params)

--- a/lib/logstash/outputs/amazon_es/http_client.rb
+++ b/lib/logstash/outputs/amazon_es/http_client.rb
@@ -8,21 +8,6 @@ require 'zlib'
 require 'stringio'
 
 module LogStash; module Outputs; class AmazonElasticSearch;
-  # This is a constant instead of a config option because
-  # there really isn't a good reason to configure it.
-  #
-  # The criteria used are:
-  # 1. We need a number that's less than 100MiB because ES
-  #    won't accept bulks larger than that.
-  # 2. It must be large enough to amortize the connection constant
-  #    across multiple requests.
-  # 3. It must be small enough that even if multiple threads hit this size
-  #    we won't use a lot of heap.
-  #
-  # We wound up agreeing that a number greater than 10 MiB and less than 100MiB
-  # made sense. We picked one on the lowish side to not use too much heap.
-  TARGET_BULK_BYTES = 20 * 1024 * 1024 # 20MiB
-
   class HttpClient
     attr_reader :client, :options, :logger, :pool, :action_count, :recv_count, :target_bulk_bytes
     

--- a/lib/logstash/outputs/amazon_es/http_client.rb
+++ b/lib/logstash/outputs/amazon_es/http_client.rb
@@ -9,7 +9,7 @@ require 'stringio'
 
 module LogStash; module Outputs; class AmazonElasticSearch;
   class HttpClient
-    attr_reader :client, :options, :logger, :pool, :action_count, :recv_count, :target_bulk_bytes
+    attr_reader :client, :options, :logger, :pool, :action_count, :recv_count, :max_bulk_bytes
     
   
     # This is here in case we use DEFAULT_OPTIONS in the future
@@ -41,7 +41,7 @@ module LogStash; module Outputs; class AmazonElasticSearch;
       @metric = options[:metric]
       @bulk_request_metrics = @metric.namespace(:bulk_requests)
       @bulk_response_metrics = @bulk_request_metrics.namespace(:responses)
-      @target_bulk_bytes = options[:max_bulk_bytes] 
+      @max_bulk_bytes = options[:max_bulk_bytes] 
 
       # Again, in case we use DEFAULT_OPTIONS in the future, uncomment this.
       # @options = DEFAULT_OPTIONS.merge(options)
@@ -109,7 +109,7 @@ module LogStash; module Outputs; class AmazonElasticSearch;
                     action.map {|line| LogStash::Json.dump(line)}.join("\n") :
                     LogStash::Json.dump(action)
         as_json << "\n"
-        if (body_stream.size + as_json.bytesize) > @target_bulk_bytes
+        if (body_stream.size + as_json.bytesize) > @max_bulk_bytes
           bulk_responses << bulk_send(body_stream) unless body_stream.size == 0
         end
         stream_writer.write(as_json)

--- a/lib/logstash/outputs/amazon_es/http_client_builder.rb
+++ b/lib/logstash/outputs/amazon_es/http_client_builder.rb
@@ -101,7 +101,9 @@ module LogStash; module Outputs; class AmazonElasticSearch;
                                               :port => params["port"],
                                               :region => params["region"],
                                               :aws_access_key_id => params["aws_access_key_id"],
-                                              :aws_secret_access_key => params["aws_secret_access_key"]))
+                                              :aws_secret_access_key => params["aws_secret_access_key"],
+                                              :max_bulk_bytes => params["max_bulk_bytes"])
+                                              )
     end
 
     def self.create_http_client(options)


### PR DESCRIPTION
*Issue #, if available:*
Multiple

*Description of changes:*
Adding a configurable parameter for target bulk size in bytes, which defaults to the previous hard-coded value. The reason for making this configurable is that different instance sizes have different http request size limits, and some users may want to send larger bulks to increase throughput. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
