### PR TITLE
 Adds skip_template_installation configuration parameter

### DIFF
--- a/lib/logstash/outputs/amazon_es.rb
+++ b/lib/logstash/outputs/amazon_es.rb
@@ -261,6 +261,9 @@ class LogStash::Outputs::AmazonElasticSearch < LogStash::Outputs::Base
   #Option for user to skip Healthcheck API for a host when set to True
   config :skip_healthcheck, :validate => :boolean, :default => false
 
+  #Allow user to skip installing template when set to True
+  config :skip_template_installation, :validate => :boolean, :default => false
+
   def build_client
     params["metric"] = metric
     @client ||= ::LogStash::Outputs::AmazonElasticSearch::HttpClientBuilder.build(@logger, @hosts, params)

--- a/lib/logstash/outputs/amazon_es/common.rb
+++ b/lib/logstash/outputs/amazon_es/common.rb
@@ -6,7 +6,7 @@ require "logstash/outputs/amazon_es/template_manager"
 
 module LogStash; module Outputs; class AmazonElasticSearch;
   module Common
-    attr_reader :client, :hosts
+    attr_reader :client, :hosts, :skip_template_installation
 
     # These codes apply to documents, not at the request level
     DOC_DLQ_CODES = [400, 404]
@@ -119,8 +119,12 @@ module LogStash; module Outputs; class AmazonElasticSearch;
     end
 
     def install_template
-      TemplateManager.install_template(self)
-      @template_installed.make_true
+      if skip_template_installation == false
+       TemplateManager.install_template(self)
+       @template_installed.make_true
+      elsif skip_template_installation == true
+        @template_installed.make_true
+      end
     end
 
     def check_action_validity


### PR DESCRIPTION
*Issue #, if available:*
* Resolves #179 

*Description of changes:*
* Adds a boolean `skip_template_installation` as a configuration parameter allowing users to skip templates if needed
* Defaults to `false`
* Manually tested with different domains

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
